### PR TITLE
Add link to SteelyUK github for collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 The PyQt5-Tutorial is an introductory guide through the widgets available in the Qt5 toolkit, combined with the use of Python 3.
 
 The tutorial does not guide through the building process of an application from start to finish, but rather provides the methods and signals used by each widget, and a description of how each works.
+
+The main github repository for this documentation is [https://github.com/steeleyuk/pyqt5-tutorial]{https://github.com/steeleyuk/pyqt5-tutorial}


### PR DESCRIPTION
If I want to be able to show someone this documentation on irc I would ether have to host a mirror of this which I do not have setup and now I can just paste a link to the github page in irc if I wanted to show someone this documentation and would have cloned it to have the info locally. 